### PR TITLE
mhgui: Implement support for loading Pronto Hex codes + Misc. Bugfixes

### DIFF
--- a/congruity/mhgui.py
+++ b/congruity/mhgui.py
@@ -1287,6 +1287,7 @@ class ConfigureDevicePanel(WizardPanelBase):
         self.sizer.Add(self.hSizer, 0, 0, 0)
         self.sizer.AddSpacer(10)
 
+        # Button Row 1
         self.bottomSizer = wx.BoxSizer(wx.HORIZONTAL)
         self.updateButton = wx.Button(self, label="Update Button")
         self.updateButton.Bind(wx.EVT_BUTTON, self.OnUpdate)
@@ -1294,18 +1295,6 @@ class ConfigureDevicePanel(WizardPanelBase):
                 "Update selected button with the selected device command"
         ))
         self.bottomSizer.Add(self.updateButton, 0, 0, 0)
-        self.overrideButton = wx.Button(self, label="Override Command")
-        self.overrideButton.Bind(wx.EVT_BUTTON, self.OnOverride)
-        self.overrideButton.SetToolTip(wx.ToolTip(
-                "Learn IR command from existing remote to replace a command"
-        ))
-        self.bottomSizer.Add(self.overrideButton, 0, 0, 0)
-        self.addButton = wx.Button(self, label="Add Command")
-        self.addButton.Bind(wx.EVT_BUTTON, self.OnAdd)
-        self.addButton.SetToolTip(wx.ToolTip(
-                "Learn IR command from existing remote as a new command"
-        ))
-        self.bottomSizer.Add(self.addButton, 0, 0, 0)
         self.restoreButton = wx.Button(self, label="Restore Command")
         self.restoreButton.Bind(wx.EVT_BUTTON, self.OnRestore)
         self.restoreButton.SetToolTip(wx.ToolTip(
@@ -1313,6 +1302,48 @@ class ConfigureDevicePanel(WizardPanelBase):
         ))
         self.bottomSizer.Add(self.restoreButton, 0, 0, 0)
         self.sizer.Add(self.bottomSizer, 0, 0, 0)
+        
+        # Button Row 2
+        self.bottomRow2Sizer = wx.BoxSizer(wx.HORIZONTAL)   
+        self.learnLabel = wx.StaticText(self, -1, "Learn from Remote:       ")
+        self.bottomRow2Sizer.Add(self.learnLabel, 0, 0, 0)
+        self.overrideButton = wx.Button(self, label="Override Command")
+        self.overrideButton.Bind(wx.EVT_BUTTON, self.OnOverride)
+        self.overrideButton.SetToolTip(wx.ToolTip(
+                "Learn IR command from existing remote to replace a command"
+        ))
+        self.bottomRow2Sizer.Add(self.overrideButton, 0, 0, 0)
+        self.addButton = wx.Button(self, label="Add Command")
+        self.addButton.Bind(wx.EVT_BUTTON, self.OnAdd)
+        self.addButton.SetToolTip(wx.ToolTip(
+                "Learn IR command from existing remote as a new command"
+        ))
+        self.bottomRow2Sizer.Add(self.addButton, 0, 0, 0)
+        self.sizer.Add(self.bottomRow2Sizer, 0, 0, 0)
+        
+        # Button Row 3:
+        self.bottomRow3Sizer = wx.BoxSizer(wx.HORIZONTAL)     
+        self.prontoLabel = wx.StaticText(self, -1, "Import Pronto Hex:        ")
+        self.bottomRow3Sizer.Add(self.prontoLabel, 0, 0, 0)
+        self.overrideProntoButton = wx.Button(self, label="Override Command")
+        self.overrideProntoButton.Bind(wx.EVT_BUTTON, self.OnOverridePronto)
+        self.overrideProntoButton.SetToolTip(wx.ToolTip(
+                "Load IR command from Pronto Hex to replace a command"
+        ))
+        self.bottomRow3Sizer.Add(self.overrideProntoButton, 0, 0, 0)
+        self.addProntoButton = wx.Button(self, label="Add Command")
+        self.addProntoButton.Bind(wx.EVT_BUTTON, self.OnAddPronto)
+        self.addProntoButton.SetToolTip(wx.ToolTip(
+                "Load IR command from Pronto Hex as a new command"
+        ))        
+        self.bottomRow3Sizer.Add(self.addProntoButton, 0, 0, 0)
+        self.optionsProntoButton = wx.Button(self, label="Pronto Options")
+        self.optionsProntoButton.Bind(wx.EVT_BUTTON, self.OnProntoOptions)
+        self.optionsProntoButton.SetToolTip(wx.ToolTip(
+                "Set parsing parameters for Pronto Hex Codes"
+        ))        
+        self.bottomRow3Sizer.Add(self.optionsProntoButton, 0, 0, 0)        
+        self.sizer.Add(self.bottomRow3Sizer, 0, 0, 0)
 
         self.SetSizerAndFit(self.sizer)
 
@@ -1466,6 +1497,47 @@ class ConfigureDevicePanel(WizardPanelBase):
             return
         command = dlg.GetValue()
         self.UpdateIR(command)
+        
+    def OnOverridePronto(self, event):
+        commandSelection = self.deviceCommandsListCtrl.GetFirstSelected()
+        if commandSelection == -1:
+            wx.MessageBox('Please select a command to override.',
+                          'No command selected.', wx.OK | wx.ICON_WARNING)
+            return
+        command = self.deviceCommands[commandSelection].Name
+        self.UpdateIRPronto(command)
+
+    def OnAddPronto(self, event):
+        dlg = wx.TextEntryDialog(None, "Enter the name of the new command:",
+                                 "Add Command")
+        if dlg.ShowModal() != wx.ID_OK:
+            return
+        command = dlg.GetValue()
+        self.UpdateIRPronto(command)
+        
+    def OnProntoOptions(self, event):
+        dlg = wx.TextEntryDialog(None, 
+                                 "Enter the number of times the repeating " + \
+                                 "portion of the Pronto code should be played back:",
+                                 "Pronto Repeats", str(self.resources.prontoRepeats))
+        if dlg.ShowModal() == wx.ID_OK:
+            try:
+                self.resources.prontoRepeats = int(dlg.GetValue())
+            except ValueError:
+                wx.MessageBox('Value provided is not an integer.',
+                              'Error', wx.OK | wx.ICON_WARNING)                
+        dlg = wx.TextEntryDialog(None, 
+                                 "Enter a frequency in Hz to use for the " + \
+                                 "IR carrier, or 0 to use the frequency " + \
+                                 "from the Pronto code:",
+                                 "Pronto Frequency Override", 
+                                 str(self.resources.prontoFrequencyOverride))
+        if dlg.ShowModal() == wx.ID_OK:
+            try:
+                self.resources.prontoFrequencyOverride = int(dlg.GetValue())
+            except ValueError:
+                wx.MessageBox('Value provided is not an integer.',
+                              'Error', wx.OK | wx.ICON_WARNING)                 
 
     def OnRestore(self, event):
         commandSelection = self.deviceCommandsListCtrl.GetFirstSelected()
@@ -1490,6 +1562,83 @@ class ConfigureDevicePanel(WizardPanelBase):
             wx.MessageBox('IR command deletion failed: ' + result, 'Error',
                           wx.OK | wx.ICON_WARNING)
         self.LoadDataUI(None)
+        
+    def UpdateIRPronto(self, commandName):
+        # Based on LearnIrEnterProntoHexPanel._OnValidate(self, event) in
+        # congruity.py
+        # Because we are not learning IR and we are allocating the structures 
+        # for the IR signals (and Python should garbage collect them), we do not 
+        # init or deinit libconcord, nor do we call the libconcord functions to  
+        # allocate or free these structures. We only call into libconcord to
+        # encode the signal for posting.
+        #
+        dlg = wx.TextEntryDialog(None, "Enter the Pronto Hex code for the command:",
+                                 "Pronto Hex")
+        if dlg.ShowModal() != wx.ID_OK:
+            return
+        command = dlg.GetValue()
+        try:
+            bin = []
+            str = ""
+            str_idx = 0
+
+            hex = command.strip().split(' ')
+            for h in hex:
+                b = int(h, 16)
+                bin.append(b)
+
+            if len(bin) < 4:
+                raise Exception('Pronto code too short (missing header)')
+
+            if bin[0] != 0:
+                raise Exception('Not RAW')
+
+            pronto_clock = 4145146
+            # IR carrier frequency is given as number of Pronto clock cycles
+            frequency = int(pronto_clock / bin[1])
+            # Mark/space durations are given as a count of IR carrier cycles,
+            # but we need them in microseconds
+            carrier_cycle_us = 1000000.0 / frequency
+
+            count_1 = 2 * bin[2]
+            count_2 = 2 * bin[3]
+
+            if len(bin) < 4 + count_1 + count_2:
+                raise Exception('Pronto code too short (missing pulsetrain)')
+
+            start_1 = 4
+            start_2 = 4 + count_1
+
+            repeats = self.resources.prontoRepeats
+            count = count_1 + (repeats * count_2)
+            if self.resources.prontoFrequencyOverride > 0 :
+                frequency = int(self.resources.prontoFrequencyOverride);
+            self.commandName = commandName
+            self.carrierClock = ctypes.c_uint(frequency)
+            cur_ir_signal_type = ctypes.c_uint * count
+            self.signal = cur_ir_signal_type()
+            self.signalLength = ctypes.c_uint(count)
+
+            idx = 0
+
+            for i in range(count_1):
+                self.signal[idx] = int(bin[start_1 + i] * carrier_cycle_us)
+                idx += 1
+
+            for j in range(repeats):
+                for i in range(count_2):
+                    self.signal[idx] = int(bin[start_2 + i] * carrier_cycle_us)
+                    idx += 1
+
+            self.rawSequence = ctypes.c_char_p()
+            libconcord.encode_for_posting(self.carrierClock, self.signal,
+                                          self.signalLength, self.rawSequence)
+            BackgroundTask((self.DoUpdateIR,), (self.FinishUpdateIRPronto,))
+
+            return
+        except:
+            wx.MessageBox('Could not process Pronto: ' + exception_message(), 
+                          'Error', wx.OK | wx.ICON_WARNING)                    
 
     def UpdateIR(self, commandName):
         msg = 'Please ensure your remote control is connected.'
@@ -1562,6 +1711,12 @@ class ConfigureDevicePanel(WizardPanelBase):
         libconcord.delete_ir_signal(self.signal)
         libconcord.delete_encoded_signal(self.rawSequence)
         libconcord.deinit_concord()
+        
+    def FinishUpdateIRPronto(self, result):
+        if result is not None:
+            wx.MessageBox('IR learning update failed: ' + result, 'Error',
+                          wx.OK | wx.ICON_WARNING)
+        self.LoadDataUI(None)    
 
     def GetTitle(self):
         return "Device Configuration"
@@ -2985,6 +3140,8 @@ class Wizard(wx.Dialog):
             (page, data) = self.cur_page.OnActivated(prev_page, data)
 
 class Resources(object):
+    prontoRepeats = 4
+    prontoFrequencyOverride = 0
     def LoadImages(self):
         def load(filename):
             fpath = os.path.join(os.path.dirname(__file__), filename)

--- a/congruity/mhgui.py
+++ b/congruity/mhgui.py
@@ -1593,6 +1593,10 @@ class ConfigureDevicePanel(WizardPanelBase):
             if bin[0] != 0:
                 raise Exception('Not RAW')
 
+            # If we choose to override the carrier frequency, we do not want to
+            # change the mark/space duration from the Pronto code. So we will
+            # use the embedded frequency always to calculate carrier_cycle_us.
+            # We can override the frequency later.
             pronto_clock = 4145146
             # IR carrier frequency is given as number of Pronto clock cycles
             frequency = int(pronto_clock / bin[1])
@@ -1611,6 +1615,8 @@ class ConfigureDevicePanel(WizardPanelBase):
 
             repeats = self.resources.prontoRepeats
             count = count_1 + (repeats * count_2)
+            # Now we can override the frequency given that we have the correct
+            # carrier_cycle_us value.
             if self.resources.prontoFrequencyOverride > 0 :
                 frequency = int(self.resources.prontoFrequencyOverride);
             self.commandName = commandName

--- a/congruity/mhgui.py
+++ b/congruity/mhgui.py
@@ -346,7 +346,7 @@ class WelcomePanel(WizardPanelBase):
 class RemoteSelectPanel(WizardPanelBase):
     _msg_welcome = (
         "Please select a remote control below.\n\n" +
-        "Remotes (maximum of 6 per account):"
+        "Remotes (maximum of 15 per account):"
     )
 
     def __init__(self, parent, resources):
@@ -431,8 +431,8 @@ class RemoteSelectPanel(WizardPanelBase):
         BackgroundTask((self.LoadAddRemoteData,), (self.DoAddRemote,))
 
     def DoAddRemote(self, loadResult):
-        if len(self.remotes) >= 6:
-            wx.MessageBox('Each account can support up to 6 remotes.',
+        if len(self.remotes) >= 15:
+            wx.MessageBox('Each account can support up to 15 remotes.',
                           'Maximum Number of Remotes Reached',
                           wx.OK | wx.ICON_WARNING)
             return            

--- a/congruity/mhgui.py
+++ b/congruity/mhgui.py
@@ -386,9 +386,11 @@ class RemoteSelectPanel(WizardPanelBase):
     def LoadData(self):
         self.remotes = mhMgr.GetRemotes()
         self.remoteDisplayNames = []
+        index = 1
         for remote in self.remotes:
             product = mhMgr.GetProduct(remote.SkinId)
-            self.remoteDisplayNames.append(product.DisplayName)
+            self.remoteDisplayNames.append(f"{index}: {product.DisplayName}")
+            index += 1
 
     def AddRemote(self, serialNumber, skinId, usbPid, usbVid):
         result = mhMgr.AddRemote(serialNumber, skinId, usbPid, usbVid)

--- a/congruity/mhmanager.py
+++ b/congruity/mhmanager.py
@@ -28,6 +28,7 @@ import random
 import datetime
 import json
 import html
+from pathlib import Path
 from six.moves.html_parser import HTMLParser
 from suds.cache import ObjectCache
 from suds.client import Client
@@ -154,7 +155,9 @@ class MHManager():
     def __init__(self, use_local_wsdl=False, suds_debug=False):
         if use_local_wsdl:
             wsdl = os.path.join(os.path.dirname(__file__), 'harmony.wsdl')
-            url = 'file://' + wsdl
+            # pathlib automatically takes care of the differences when 
+            # constructing a file URI on Windows vs. Linux/Mac
+            url = Path(wsdl).as_uri()
             cache = None
         else:
             url = 'https://congruity.sourceforge.io/congruity/harmony.wsdl'


### PR DESCRIPTION
While congruity.py supports the use of Pronto Hex codes in lieu of learning an IR command, mhgui.py does not. This is a pull request to add support for importing Pronto codes to mhgui.py, so that you can load Pronto codes on newer remotes. In addition, options have been added to customize the parsing of the Pronto codes - specifically, the number of repeats and IR frequency. 

The core logic is borrowed from congruity.py's Pronto code implementation. The intent here is to provide a basic implementation of the feature. All feedback is appreciated.

I have also included a few small bugfixes with this pull request:
- Increase number of supported remotes from 6 to 15 to reflect the current limitations of myharmony.com
- Number each remote in the selection list so the user doesn't have to count. (I have 10 on my account, all of them 650's. Prior to this it just showed 10 identical entries that said "Harmony 650".) This simply numbers the remotes, it does not attempt to number them by model unlike the Logitech software.
- Fix the --use-local-wsdl option on Windows. (On Windows the file:// URI being constructed to load the WSDL was invalid. I changed it to use pathlib to do it in a platform-independent manner.)
