### PR TITLE
Show file open dialog if congruity is opened without a provided filename

### DIFF
--- a/congruity/congruity.py
+++ b/congruity/congruity.py
@@ -1864,7 +1864,8 @@ def main():
                 raise CmdLineException("ERROR: Option '%s' not recognized" % arg)
         if len(argv) != 1:
             # We did not get a file name on the command line, prompt the user for one.
-            with wx.FileDialog(None, "Congruity - Open a file", wildcard="EZHex files (*.ez*)|*.ez*",
+            with wx.FileDialog(None, "Congruity - Open a file", 
+                               wildcard="EZHex files (*.EZHex;*.EZUp;*.EZTut)|*.EZHex;*.EZUp;*.EZTut",
                                style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST) as fileDialog:
                 if fileDialog.ShowModal() == wx.ID_CANCEL:
                     os._exit(1)

--- a/congruity/congruity.py
+++ b/congruity/congruity.py
@@ -1863,8 +1863,14 @@ def main():
             else:
                 raise CmdLineException("ERROR: Option '%s' not recognized" % arg)
         if len(argv) != 1:
-            raise CmdLineException("ERROR: Precisely one filename argument is required")
-        ezhex_filename = argv.pop(0)
+            # We did not get a file name on the command line, prompt the user for one.
+            with wx.FileDialog(None, "Congruity - Open a file", wildcard="EZHex files (*.ez*)|*.ez*",
+                               style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST) as fileDialog:
+                if fileDialog.ShowModal() == wx.ID_CANCEL:
+                    os._exit(1)
+                ezhex_filename = fileDialog.GetPath()
+        else:
+            ezhex_filename = argv.pop(0)
         initial_exception = None
     except:
         ezhex_filename = None


### PR DESCRIPTION
With this PR, Congruity will now show an Open File dialog if no file name is passed to it on the command line, as opposed to erroring out. This way, it can be used without having to provide a command-line argument or file type association (for example, launching from the Start menu).