### PR TITLE
MHGUI: Add support for importing GIRR files with Pronto codes

### DIFF
--- a/girr_test_cases/10-pronto_codes_invalid_3.girr
+++ b/girr_test_cases/10-pronto_codes_invalid_3.girr
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="WINDOWS-1252" standalone="no"?>
+<!--This file is in the Girr (General IR Remote) format, see http://www.harctoolbox.org/Girr.html--><remotes xmlns="http://www.harctoolbox.org/Girr" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" girrVersion="1.2" title="IrScrutinizer parametric export" xsi:schemaLocation="http://www.harctoolbox.org/Girr http://www.harctoolbox.org/schemas/girr_ns-1.2.xsd">
+    <adminData>
+        <creationData creatingUser="user" creationDate="2024-04-20_21:39:10" tool="IrScrutinizer" tool2="IrpTransmogrifier" tool2Version="1.2.11" toolVersion="2.4.0"/>
+    </adminData>
+    <remote comment="Export from IrScrutinizer" deviceClass="Cable" displayName="" manufacturer="" model="" name="remote" remoteName="XR100">
+        <commandSet name="commandSet">
+            <parameters protocol="XMP-1">
+                <parameter name="S" value="1"/>
+                <parameter name="D" value="62"/>
+            </parameters>
+            <command F="15" master="parameters" name="ProntoInvalid3">
+                <ccf>0000 006D 0012 0012</ccf>
+            </command>
+        </commandSet>
+    </remote>
+</remotes>

--- a/girr_test_cases/11-invalid_xml_1.girr
+++ b/girr_test_cases/11-invalid_xml_1.girr
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="WINDOWS-1252" standalone="no"?>
+<!--This file is in the Girr (General IR Remote) format, see http://www.harctoolbox.org/Girr.html--><remotes xmlns="http://www.harctoolbox.org/Girr" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" girrVersion="1.2" title="IrScrutinizer parametric export" xsi:schemaLocation="http://www.harctoolbox.org/Girr http://www.harctoolbox.org/schemas/girr_ns-1.2.xsd">
+    <adminData>
+        <creationData creatingUser="user" creationDate="2024-04-20_21:39:10" tool="IrScrutinizer" tool2="IrpTransmogrifier" tool2Version="1.2.11" toolVersion="2.4.0"/>
+    </adminData>
+    <remote comment="Export from IrScrutinizer" deviceClass="Cable" displayName="" manufacturer="" model="" name="remote" remoteName="XR100">
+        <commandSet name="commandSet">
+            <parameters protocol="XMP-1">
+                <parameter name="S" value="1"/>
+                <parameter name="D" value="62"/>
+            </parameters>
+            <command F="15" master="parameters" name="ClosingTagMissing">
+                <ccf>0000 006D 0012 0012 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 001D 0008 001D 0008 0022 0008 001D 0008 006A 0008 001D 0008 001D 0008 0BEF 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 0046 0008 0046 0008 0022 0008 001D 0008 006A 0008 001D 0008 001D 0008 0BEF</ccf>
+        </commandSet>
+    </remote>
+</remotes>

--- a/girr_test_cases/12-duplicate_names.girr
+++ b/girr_test_cases/12-duplicate_names.girr
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="WINDOWS-1252" standalone="no"?>
+<!--This file is in the Girr (General IR Remote) format, see http://www.harctoolbox.org/Girr.html--><remotes xmlns="http://www.harctoolbox.org/Girr" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" girrVersion="1.2" title="IrScrutinizer parametric export" xsi:schemaLocation="http://www.harctoolbox.org/Girr http://www.harctoolbox.org/schemas/girr_ns-1.2.xsd">
+    <adminData>
+        <creationData creatingUser="user" creationDate="2024-04-20_21:39:10" tool="IrScrutinizer" tool2="IrpTransmogrifier" tool2Version="1.2.11" toolVersion="2.4.0"/>
+    </adminData>
+    <remote comment="Export from IrScrutinizer" deviceClass="Cable" displayName="" manufacturer="" model="" name="remote" remoteName="XR100">
+        <commandSet name="commandSet">
+            <parameters protocol="XMP-1">
+                <parameter name="S" value="1"/>
+                <parameter name="D" value="62"/>
+            </parameters>
+            <command F="15" master="parameters" name="DuplicateName">
+                <ccf>0000 006D 0012 0012 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 001D 0008 001D 0008 0022 0008 001D 0008 006A 0008 001D 0008 001D 0008 0BEF 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 0046 0008 0046 0008 0022 0008 001D 0008 006A 0008 001D 0008 001D 0008 0BEF</ccf>
+            </command>
+            <command F="15" master="parameters" name="DuplicateName">
+                <ccf>0000 006D 0012 0012 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 001D 0008 001D 0008 0022 0008 001D 0008 006A 0008 001D 0008 001D 0008 0BEF 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 0046 0008 0046 0008 0022 0008 001D 0008 006A 0008 001D 0008 001D 0008 0BEF</ccf>
+            </command>
+        </commandSet>
+    </remote>
+</remotes>

--- a/girr_test_cases/13-more_than_one_code.girr
+++ b/girr_test_cases/13-more_than_one_code.girr
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="WINDOWS-1252" standalone="no"?>
+<!--This file is in the Girr (General IR Remote) format, see http://www.harctoolbox.org/Girr.html--><remotes xmlns="http://www.harctoolbox.org/Girr" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" girrVersion="1.2" title="IrScrutinizer parametric export" xsi:schemaLocation="http://www.harctoolbox.org/Girr http://www.harctoolbox.org/schemas/girr_ns-1.2.xsd">
+    <adminData>
+        <creationData creatingUser="user" creationDate="2024-04-20_21:39:10" tool="IrScrutinizer" tool2="IrpTransmogrifier" tool2Version="1.2.11" toolVersion="2.4.0"/>
+    </adminData>
+    <remote comment="Export from IrScrutinizer" deviceClass="Cable" displayName="" manufacturer="" model="" name="remote" remoteName="XR100">
+        <commandSet name="commandSet">
+            <parameters protocol="XMP-1">
+                <parameter name="S" value="1"/>
+                <parameter name="D" value="62"/>
+            </parameters>
+            <command F="15" master="parameters" name="MoreThanOneCode">
+                <ccf>0000 006D 0012 0012 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 001D 0008 001D 0008 0022 0008 001D 0008 006A 0008 001D 0008 001D 0008 0BEF 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 0046 0008 0046 0008 0022 0008 001D 0008 006A 0008 001D 0008 001D 0008 0BEF</ccf>
+                <ccf>0000 006D 0012 0012 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 001D 0008 001D 0008 0022 0008 001D 0008 006A 0008 001D 0008 001D 0008 0BEF 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 0046 0008 0046 0008 0022 0008 001D 0008 006A 0008 001D 0008 001D 0008 0BEF</ccf>
+            </command>
+        </commandSet>
+    </remote>
+</remotes>

--- a/girr_test_cases/14-code_too_long.girr
+++ b/girr_test_cases/14-code_too_long.girr
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="WINDOWS-1252" standalone="no"?>
+<!--This file is in the Girr (General IR Remote) format, see http://www.harctoolbox.org/Girr.html--><remotes xmlns="http://www.harctoolbox.org/Girr" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" girrVersion="1.2" title="IrScrutinizer parametric export" xsi:schemaLocation="http://www.harctoolbox.org/Girr http://www.harctoolbox.org/schemas/girr_ns-1.2.xsd">
+    <adminData>
+        <creationData creatingUser="user" creationDate="2024-04-20_21:39:10" tool="IrScrutinizer" tool2="IrpTransmogrifier" tool2Version="1.2.11" toolVersion="2.4.0"/>
+    </adminData>
+    <remote comment="Export from IrScrutinizer" deviceClass="Cable" displayName="" manufacturer="" model="" name="remote" remoteName="XR100">
+        <commandSet name="commandSet">
+            <parameters protocol="XMP-1">
+                <parameter name="S" value="1"/>
+                <parameter name="D" value="62"/>
+            </parameters>
+            <command F="15" master="parameters" name="MoreThanOneCode">
+                <ccf>0000 006D 0012 0012 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 001D 0008 001D 0008 0022 0008 001D 0008 006A 0008 001D 0008 001D 0008 0BEF 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 0046 0008 0046 0008 0022 0008 001D 0008 006A 0008 001D 0008 001D 0008 0BEF 0000 006D 0012 0012 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 001D 0008 001D 0008 0022 0008 001D 0008 006A 0008 001D 0008 001D 0008 0BEF 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 0046 0008 0046 0008 0022 0008 001D 0008 006A 0008 001D 0008 001D 0008 0BEF</ccf>
+            </command>
+        </commandSet>
+    </remote>
+</remotes>

--- a/girr_test_cases/15-good_sample.girr
+++ b/girr_test_cases/15-good_sample.girr
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="WINDOWS-1252" standalone="no"?>
+<!--This file is in the Girr (General IR Remote) format, see http://www.harctoolbox.org/Girr.html--><remotes xmlns="http://www.harctoolbox.org/Girr" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" girrVersion="1.2" title="IrScrutinizer parametric export" xsi:schemaLocation="http://www.harctoolbox.org/Girr http://www.harctoolbox.org/schemas/girr_ns-1.2.xsd">
+    <adminData>
+        <creationData creatingUser="user" creationDate="2024-04-20_21:39:10" tool="IrScrutinizer" tool2="IrpTransmogrifier" tool2Version="1.2.11" toolVersion="2.4.0"/>
+    </adminData>
+    <remote comment="Export from IrScrutinizer" deviceClass="Cable" displayName="Xumo Stream Box (XR100 Remote)" manufacturer="Sercomm/Comcast" model="XiOne-SC(B) with Xfinity Codeset" name="remote" remoteName="XR100">
+        <commandSet name="commandSet">
+            <parameters protocol="XMP-1">
+                <parameter name="S" value="1"/>
+                <parameter name="D" value="62"/>
+            </parameters>
+            <command F="15" master="parameters" name="PowerToggle">
+                <ccf>0000 006D 0012 0012 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 001D 0008 001D 0008 0022 0008 001D 0008 006A 0008 001D 0008 001D 0008 0BEF 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 0046 0008 0046 0008 0022 0008 001D 0008 006A 0008 001D 0008 001D 0008 0BEF</ccf>
+            </command>
+            <command F="15" master="parameters" name="PowerOff" displayName="Alias of PowerToggle">
+                <ccf>0000 006D 0012 0012 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 001D 0008 001D 0008 0022 0008 001D 0008 006A 0008 001D 0008 001D 0008 0BEF 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 0046 0008 0046 0008 0022 0008 001D 0008 006A 0008 001D 0008 001D 0008 0BEF</ccf>
+            </command>
+            <command F="87" master="parameters" name="Input">
+                <ccf>0000 006D 0012 0012 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 002C 0008 001D 0008 0022 0008 0037 0008 0041 0008 001D 0008 001D 0008 0BEF 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 0056 0008 0046 0008 0022 0008 0037 0008 0041 0008 001D 0008 001D 0008 0BEF</ccf>
+            </command>
+            <command F="1" master="parameters" name="1">
+                <ccf>0000 006D 0012 0012 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 0065 0008 001D 0008 0022 0008 001D 0008 0022 0008 001D 0008 001D 0008 0BEF 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 003C 0008 0046 0008 0022 0008 001D 0008 0022 0008 001D 0008 001D 0008 0BEF</ccf>
+            </command>
+        </commandSet>
+    </remote>
+</remotes>

--- a/girr_test_cases/2-text_file.girr
+++ b/girr_test_cases/2-text_file.girr
@@ -1,0 +1,1 @@
+This is not a valid GIRR file.

--- a/girr_test_cases/3-no_commands_in_file.girr
+++ b/girr_test_cases/3-no_commands_in_file.girr
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="WINDOWS-1252" standalone="no"?>
+<!--This file is in the Girr (General IR Remote) format, see http://www.harctoolbox.org/Girr.html--><remotes xmlns="http://www.harctoolbox.org/Girr" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" girrVersion="1.2" title="IrScrutinizer parametric export" xsi:schemaLocation="http://www.harctoolbox.org/Girr http://www.harctoolbox.org/schemas/girr_ns-1.2.xsd">
+    <adminData>
+        <creationData creatingUser="user" creationDate="2024-04-20_21:39:10" tool="IrScrutinizer" tool2="IrpTransmogrifier" tool2Version="1.2.11" toolVersion="2.4.0"/>
+    </adminData>
+    <remote comment="Export from IrScrutinizer" deviceClass="Cable" displayName="No Commands in File" manufacturer="" model="" name="remote" remoteName="">
+        <commandSet name="commandSet">
+        </commandSet>
+    </remote>
+</remotes>

--- a/girr_test_cases/4-name_attribute_missing.girr
+++ b/girr_test_cases/4-name_attribute_missing.girr
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="WINDOWS-1252" standalone="no"?>
+<!--This file is in the Girr (General IR Remote) format, see http://www.harctoolbox.org/Girr.html--><remotes xmlns="http://www.harctoolbox.org/Girr" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" girrVersion="1.2" title="IrScrutinizer parametric export" xsi:schemaLocation="http://www.harctoolbox.org/Girr http://www.harctoolbox.org/schemas/girr_ns-1.2.xsd">
+    <adminData>
+        <creationData creatingUser="user" creationDate="2024-04-20_21:39:10" tool="IrScrutinizer" tool2="IrpTransmogrifier" tool2Version="1.2.11" toolVersion="2.4.0"/>
+    </adminData>
+    <remote comment="Export from IrScrutinizer" deviceClass="Cable" displayName="" manufacturer="" model="" name="remote" remoteName="XR100">
+        <commandSet name="commandSet">
+            <parameters protocol="XMP-1">
+                <parameter name="S" value="1"/>
+                <parameter name="D" value="62"/>
+            </parameters>
+            <command F="15" master="parameters">
+                <ccf>0000 006D 0012 0012 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 001D 0008 001D 0008 0022 0008 001D 0008 006A 0008 001D 0008 001D 0008 0BEF 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 0046 0008 0046 0008 0022 0008 001D 0008 006A 0008 001D 0008 001D 0008 0BEF</ccf>
+            </command>
+        </commandSet>
+    </remote>
+</remotes>

--- a/girr_test_cases/5-name_attribute_empty.girr
+++ b/girr_test_cases/5-name_attribute_empty.girr
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="WINDOWS-1252" standalone="no"?>
+<!--This file is in the Girr (General IR Remote) format, see http://www.harctoolbox.org/Girr.html--><remotes xmlns="http://www.harctoolbox.org/Girr" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" girrVersion="1.2" title="IrScrutinizer parametric export" xsi:schemaLocation="http://www.harctoolbox.org/Girr http://www.harctoolbox.org/schemas/girr_ns-1.2.xsd">
+    <adminData>
+        <creationData creatingUser="user" creationDate="2024-04-20_21:39:10" tool="IrScrutinizer" tool2="IrpTransmogrifier" tool2Version="1.2.11" toolVersion="2.4.0"/>
+    </adminData>
+    <remote comment="Export from IrScrutinizer" deviceClass="Cable" displayName="" manufacturer="" model="" name="remote" remoteName="XR100">
+        <commandSet name="commandSet">
+            <parameters protocol="XMP-1">
+                <parameter name="S" value="1"/>
+                <parameter name="D" value="62"/>
+            </parameters>
+            <command F="15" master="parameters" name="">
+                <ccf>0000 006D 0012 0012 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 001D 0008 001D 0008 0022 0008 001D 0008 006A 0008 001D 0008 001D 0008 0BEF 0008 001D 0008 0041 0008 0022 0008 006A 0008 0032 0008 0032 0008 002C 0008 0065 0008 020C 0008 001D 0008 0046 0008 0046 0008 0022 0008 001D 0008 006A 0008 001D 0008 001D 0008 0BEF</ccf>
+            </command>
+        </commandSet>
+    </remote>
+</remotes>

--- a/girr_test_cases/6-pronto_codes_not_present_1.girr
+++ b/girr_test_cases/6-pronto_codes_not_present_1.girr
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="WINDOWS-1252" standalone="no"?>
+<!--This file is in the Girr (General IR Remote) format, see http://www.harctoolbox.org/Girr.html--><remotes xmlns="http://www.harctoolbox.org/Girr" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" girrVersion="1.2" title="IrScrutinizer parametric export" xsi:schemaLocation="http://www.harctoolbox.org/Girr http://www.harctoolbox.org/schemas/girr_ns-1.2.xsd">
+    <adminData>
+        <creationData creatingUser="user" creationDate="2024-04-20_21:39:10" tool="IrScrutinizer" tool2="IrpTransmogrifier" tool2Version="1.2.11" toolVersion="2.4.0"/>
+    </adminData>
+    <remote comment="Export from IrScrutinizer" deviceClass="Cable" displayName="" manufacturer="" model="" name="remote" remoteName="XR100">
+        <commandSet name="commandSet">
+            <parameters protocol="XMP-1">
+                <parameter name="S" value="1"/>
+                <parameter name="D" value="62"/>
+            </parameters>
+            <command F="15" master="parameters" name="ProntoNotPresent1">
+                
+            </command>
+        </commandSet>
+    </remote>
+</remotes>

--- a/girr_test_cases/7-pronto_codes_not_present_2.girr
+++ b/girr_test_cases/7-pronto_codes_not_present_2.girr
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="WINDOWS-1252" standalone="no"?>
+<!--This file is in the Girr (General IR Remote) format, see http://www.harctoolbox.org/Girr.html--><remotes xmlns="http://www.harctoolbox.org/Girr" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" girrVersion="1.2" title="IrScrutinizer parametric export" xsi:schemaLocation="http://www.harctoolbox.org/Girr http://www.harctoolbox.org/schemas/girr_ns-1.2.xsd">
+    <adminData>
+        <creationData creatingUser="user" creationDate="2024-04-20_21:39:10" tool="IrScrutinizer" tool2="IrpTransmogrifier" tool2Version="1.2.11" toolVersion="2.4.0"/>
+    </adminData>
+    <remote comment="Export from IrScrutinizer" deviceClass="Cable" displayName="" manufacturer="" model="" name="remote" remoteName="XR100">
+        <commandSet name="commandSet">
+            <parameters protocol="XMP-1">
+                <parameter name="S" value="1"/>
+                <parameter name="D" value="62"/>
+            </parameters>
+            <command F="15" master="parameters" name="ProntoNotPresent2">
+                <ccf></ccf>
+            </command>
+        </commandSet>
+    </remote>
+</remotes>

--- a/girr_test_cases/8-pronto_codes_invalid_1.girr
+++ b/girr_test_cases/8-pronto_codes_invalid_1.girr
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="WINDOWS-1252" standalone="no"?>
+<!--This file is in the Girr (General IR Remote) format, see http://www.harctoolbox.org/Girr.html--><remotes xmlns="http://www.harctoolbox.org/Girr" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" girrVersion="1.2" title="IrScrutinizer parametric export" xsi:schemaLocation="http://www.harctoolbox.org/Girr http://www.harctoolbox.org/schemas/girr_ns-1.2.xsd">
+    <adminData>
+        <creationData creatingUser="user" creationDate="2024-04-20_21:39:10" tool="IrScrutinizer" tool2="IrpTransmogrifier" tool2Version="1.2.11" toolVersion="2.4.0"/>
+    </adminData>
+    <remote comment="Export from IrScrutinizer" deviceClass="Cable" displayName="" manufacturer="" model="" name="remote" remoteName="XR100">
+        <commandSet name="commandSet">
+            <parameters protocol="XMP-1">
+                <parameter name="S" value="1"/>
+                <parameter name="D" value="62"/>
+            </parameters>
+            <command F="15" master="parameters" name="ProntoInvalid1">
+                <ccf> </ccf>
+            </command>
+        </commandSet>
+    </remote>
+</remotes>

--- a/girr_test_cases/9-pronto_codes_invalid_2.girr
+++ b/girr_test_cases/9-pronto_codes_invalid_2.girr
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="WINDOWS-1252" standalone="no"?>
+<!--This file is in the Girr (General IR Remote) format, see http://www.harctoolbox.org/Girr.html--><remotes xmlns="http://www.harctoolbox.org/Girr" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" girrVersion="1.2" title="IrScrutinizer parametric export" xsi:schemaLocation="http://www.harctoolbox.org/Girr http://www.harctoolbox.org/schemas/girr_ns-1.2.xsd">
+    <adminData>
+        <creationData creatingUser="user" creationDate="2024-04-20_21:39:10" tool="IrScrutinizer" tool2="IrpTransmogrifier" tool2Version="1.2.11" toolVersion="2.4.0"/>
+    </adminData>
+    <remote comment="Export from IrScrutinizer" deviceClass="Cable" displayName="" manufacturer="" model="" name="remote" remoteName="XR100">
+        <commandSet name="commandSet">
+            <parameters protocol="XMP-1">
+                <parameter name="S" value="1"/>
+                <parameter name="D" value="62"/>
+            </parameters>
+            <command F="15" master="parameters" name="ProntoInvalid2">
+                <ccf>This is not a valid pronto code.</ccf>
+            </command>
+        </commandSet>
+    </remote>
+</remotes>

--- a/girr_test_cases/README.md
+++ b/girr_test_cases/README.md
@@ -1,0 +1,19 @@
+# GIRR Test Case Files
+
+|ID|Test Case                                              |Valid XML|Expected Result|
+|--|-------------------------------------------------------|---------|---------------|
+| 1|Empty File                                             |No       |Reject File    |
+| 2|Text File                                              |No       |Reject File    |
+| 3|No Command elements in File                            |Yes      |Reject File    |
+| 4|Name Attribute Missing from Command                    |Yes      |Reject File    |
+| 5|Name Attribute Empty but Present in Command            |Yes      |Reject File    |
+| 6|Pronto Codes Not Present for command, variant 1        |Yes      |Reject File    |
+| 7|Pronto Codes Not Present for command, variant 2        |Yes      |Reject File    |
+| 8|Pronto Codes Present for command but Invalid, variant 1|Yes      |Reject File    |
+| 9|Pronto Codes Present for command but Invalid, variant 2|Yes      |Reject File    |
+|10|Pronto Codes Present for command but Invalid, variant 3|Yes      |Reject File    |
+|11|Invalid XML Syntax                                     |No       |Reject File    |
+|12|Commands have Duplicate Names                          |Yes      |Reject File    |
+|13|More than one Pronto code present for command          |Yes      |Reject File    |
+|14|Pronto Code too long per headers                       |Yes      |Reject File    |
+|15|Good Sample (small)                                    |Yes      |**Accept** File|


### PR DESCRIPTION
This pull request adds basic support for importing Pronto CCF codes from  [GIRR](https://github.com/bengtmartensson/Girr?tab=readme-ov-file) files into MHGUI. While it is possible to import a whole remote into MHGUI by copy-pasting Pronto codes, it is a laborious process when more than a few buttons are involved. GIRR files enable you to specify the contents of an entire remote as Pronto codes, substantially reducing the amount of time and effort it takes to import. This also significantly increases the number of devices we can support, as the contents of remote code databases such as the JP1 database, LIRC configs, GIRRLIB and others can be converted to GIRR and imported.

This is meant as an addition to the ability to manually load Pronto codes using the GUI as added in a previous pull request, not to replace it. It is still useful to be able to add an individual button to an otherwise functional device.

When importing the commands from the GIRR file, we first validate the file. Then, we compare it to the current commands stored in the database. We then show the user exactly which commands will be *overridden*, *added*, and *unchanged* by importing the file, and give the user the opportunity to accept or reject the changes.

Notes:
- This change is scoped to GIRR files where the Pronto CCF codes have been rendered. In the event that one has a GIRR file that doesn't have the Pronto CCF embedded, [IrScrutinizer](https://github.com/bengtmartensson/IrScrutinizer) may be used to render the GIRR into the appropriate format.
    * Open the GIRR in IrScrutinizer.
    * Set Options > Output Text Format to Pronto HEX
    * Go to File > Export > Parametrized Signals > GIRR
- The current implementation expects GIRR files with one `remote` and one `commandSet`. If there are more than one, all commands will be imported from all of them. If your GIRR file has items you do not want to import, simply copy the file and remove them from the copy.
- Commands are indexed by the `name` attribute of the `command` element, and are imported/compared to the Harmony remote in a case-sensitive manner. It is recommended to name the commands in the GIRR file using the Harmony conventions as seen in MHGUI.