### PR TITLE
mhgui: Make dialog box resizable

### DIFF
--- a/congruity/mhgui.py
+++ b/congruity/mhgui.py
@@ -3112,7 +3112,10 @@ class Wizard(wx.Dialog):
         self.min_page_width = min_page_width
         self.min_page_height = min_page_height
 
-        wx.Dialog.__init__(self, None, -1, 'MHGUI version ' + version)
+        dialog_style = wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER | \
+                       wx.MAXIMIZE_BOX | wx.MINIMIZE_BOX
+        wx.Dialog.__init__(self, None, -1, 'MHGUI version ' + version,
+                           style=dialog_style)
 
         sizer_main = wx.BoxSizer(wx.VERTICAL)
 


### PR DESCRIPTION
At least while configuring the activities, the default size of the dialog was to small for me and I could not access all the settings.

This will make the dialog box resizable and add a maximize and minimize button like a normal application window.